### PR TITLE
Fix module enumeration and matching

### DIFF
--- a/helper/main.cc
+++ b/helper/main.cc
@@ -13,7 +13,7 @@ void PrintProcessInfo(DWORD processID) {
     HMODULE hMods[1024];
     DWORD cbNeeded;
 
-    if (EnumProcessModules(hProcess, hMods, sizeof(hMods), &cbNeeded)) {
+    if (EnumProcessModulesEx(hProcess, hMods, sizeof(hMods), &cbNeeded, LIST_MODULES_ALL)) {
       TCHAR szProcessName[MAX_PATH] = TEXT("<unknown>");
       GetModuleBaseName(hProcess, hMods[0], szProcessName,
                         sizeof(szProcessName) / sizeof(TCHAR));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,15 @@ async function getMatchingProcesses(helperPath: string, options: { processName?:
 			return info.moduleIndex === "1";
 		}
 
+		if (options.processName && options.moduleName) {
+			if (!info.moduleName) {
+				return false;
+			}
+			return info.processName === options.processName && info.moduleName === options.moduleName;
+		}
+
 		if (options.processName) {
-			return info.processName === options.processName;
+			return info.processName === options.processName && info.moduleIndex === "1";
 		}
 
 		if (options.moduleName) {


### PR DESCRIPTION
Hello,
I find this extension very useful, but there was one very annoying problem:

I am waiting for x86 process and the helper is x64, therefore helper executable for some reason couldn't list x86 modules in that process, so I couldn't use `moduleName` argument.

When waiting for `processName`, all its modules showed up to pick one from. It was very annoying and pointless having to select one of the options, especially if it doesn't even matter what option I select.

And btw, `processName` + `moduleName` arguments worked like an `or` operation and not `and`. I think it should select a process that satisfies both requirements.

I hope you would publish the changes, so other collaborators from my project (and not only) could use it.